### PR TITLE
Add map support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "tap-nyan": "0.0.2"
   },
   "dependencies": {
-    "lodash": "^4.5.1",
-    "shallow-copy": "0.0.1"
+    "lodash": "^4.5.1"
   },
   "ava": {
     "require": [

--- a/src/mapReducers.js
+++ b/src/mapReducers.js
@@ -1,0 +1,20 @@
+
+import _ from 'lodash'
+
+export const mapInsertReducer = (
+  state,
+  action
+) => {
+  const newState = _.clone(state)
+  newState.set(action.insertKey, action.data)
+  return newState
+}
+
+export const mapDeleteReducer = (
+  state,
+  action
+) => {
+  const newState = _.clone(state)
+  newState.delete(action.deleteKey)
+  return newState
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,5 @@
+
+export function isMap(obj) {
+  return Object.getPrototypeOf(obj) === Map.prototype
+  || obj.constructor.name === 'Map' // Ava has a map shim which doesn't play nicely
+}

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -1,0 +1,86 @@
+
+import test from 'ava'
+import deepFreeze from 'deep-freeze'
+import _ from 'lodash'
+
+import merge from '../src/merge'
+import { mapInsertReducer, mapDeleteReducer } from '../src/mapReducers'
+import { updateReducer } from '../src/updateReducers'
+
+const mapReducer = merge({
+  'models': {
+    'add': mapInsertReducer,
+    'delete': mapDeleteReducer
+  },
+  'models[modelId]': {
+    'update': updateReducer
+  }
+})
+
+test('Add model', (t) => {
+  const action = {
+    type: 'models.add',
+    addIndex: 'abcde',
+    data: {
+      name: 'model abcde'
+    }
+  }
+
+  const stateBefore = {
+    models: new Map()
+  }
+
+  const stateAfter = {
+    models: new Map([['abcde', { name: 'model abcde' }]])
+  }
+
+  deepFreeze(action)
+  deepFreeze(stateBefore)
+  deepFreeze(stateAfter)
+  t.same(mapReducer(stateBefore, action), stateAfter)
+})
+
+test('Update model', (t) => {
+  const action = {
+    type: 'models[].update',
+    modelId: 'abcde',
+    data: {
+      name: 'updated model abcde'
+    }
+  }
+
+  const stateBefore = {
+    models: new Map([['abcde', { name: 'model abcde' }]])
+  }
+
+  const stateAfter = {
+    models: new Map([['abcde', { name: 'updated model abcde' }]])
+  }
+
+  deepFreeze(action)
+  deepFreeze(stateBefore)
+  deepFreeze(stateAfter)
+
+  t.same(mapReducer(stateBefore, action), stateAfter)
+})
+
+test('Delete model', (t) => {
+  const action = {
+    type: 'models.delete',
+    deleteKey: 'abcde'
+  }
+
+  const stateBefore = {
+    models: new Map([['abcde', { name: 'model abcde' }]])
+  }
+
+  const stateAfter = {
+    models: new Map()
+  }
+
+  deepFreeze(action)
+  deepFreeze(stateBefore)
+  deepFreeze(stateAfter)
+
+  t.same(mapReducer(stateBefore, action), stateAfter)
+})


### PR DESCRIPTION
1) Use `_.clone` for shallow cloning instead of `shallowCopy`
2) Add support for maps (Ava has a problem with shimming maps so their constructors are different, but I worked around it somewhat by comparing constructor literal names)
3) Add `mapInsertReducer` and `mapDeleteReducer`
4) Add test suite for `mapReducers`
