### PR TITLE
Refactor collection schema API

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -6,9 +6,43 @@ export function isMap(obj) {
   || obj.constructor.name === 'Map' // Ava has a map shim which doesn't play nicely
 }
 
+export function debug(map, state, action) {
+  console.log('----------------------')
+  console.log('Running process')
+  console.log('current map')
+  console.log(map)
+  console.log('current state')
+  console.log(state)
+  console.log('current action')
+  console.log(action)
+  console.log('----------------------')
+}
+
+export function getCollectionElement(collection, key) {
+  if (isMap(collection)) {
+    return collection.get(key)
+  } else {
+    return collection[key]
+  }
+}
+
+export function setCollectionElement(collection, key, value) {
+  if (isMap(collection)) {
+    collection.set(key, value)
+  } else {
+    collection[key] = value
+  }
+}
+
 export function consoleMessage(msg, debugMode) {
   if (debugMode) {
     console.log('[remerge]'.cyan + ' ' + msg)
+  }
+}
+
+export function consoleWarning(msg, debugMode) {
+  if (debugMode) {
+    console.log('[remerge]'.yellow + ' ' + msg)
   }
 }
 

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -13,22 +13,23 @@ import { arrayInsertReducer, arrayDeleteReducer } from '../src/arrayReducers'
 import { updateReducer } from '../src/updateReducers'
 
 const arrayReducer = merge({
-  'models': {
-    '_': [],
-    'add': arrayInsertReducer,
-    'delete': arrayDeleteReducer
-  },
-  'models[modelId]': {
-    'update': updateReducer,
-    'fields': {
-      'add': arrayInsertReducer,
-      'delete': arrayDeleteReducer
-    },
-    'fields[fieldId]': {
-      'update': updateReducer
+  models: {
+    _: [],
+    add: arrayInsertReducer,
+    delete: arrayDeleteReducer,
+    $modelId: {
+      update: updateReducer,
+      fields: {
+        add: arrayInsertReducer,
+        delete: arrayDeleteReducer,
+        $fieldId: {
+          update: updateReducer
+        }
+      }
     }
   }
-})
+}, true)
+
 
 test('Initial state', (t) => {
   const stateAfter = {
@@ -87,7 +88,7 @@ test('Insert model', (t) => {
 
 test('Update model', (t) => {
   const action = {
-    type  : 'models[].update',
+    type  : 'models.update',
     modelId: 0,
     data: {
       name: 'updatedModel'
@@ -136,7 +137,7 @@ test('Delete model', (t) => {
 
 test('Add field to model', (t) => {
   const action = {
-    type : 'models[].fields.add',
+    type : 'models.fields.add',
     modelId: 0,
     data: {
       name: "field a",
@@ -171,7 +172,7 @@ test('Add field to model', (t) => {
 
 test('Update field of model', (t) => {
   const action = {
-    type : 'models[].fields[].update',
+    type : 'models.fields.update',
     modelId: 0,
     fieldId: 1,
     data: {
@@ -208,7 +209,7 @@ test('Update field of model', (t) => {
 
 test('Delete field of model', (t) => {
   const action = {
-    type : 'models[].fields.delete',
+    type : 'models.fields.delete',
     modelId: 0,
     deleteIndex: 0
   }

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -8,18 +8,18 @@ import { mapInsertReducer, mapDeleteReducer } from '../src/mapReducers'
 import { updateReducer } from '../src/updateReducers'
 
 const mapReducer = merge({
-  'models': {
-    '_': new Map(),
-    'add': mapInsertReducer,
-    'delete': mapDeleteReducer
-  },
-  'models[modelId]': {
-    'update': updateReducer,
-    'fields': {
-      'add': mapInsertReducer
+  models: {
+    _: new Map(),
+    add: mapInsertReducer,
+    delete: mapDeleteReducer,
+    $modelId: {
+      update: updateReducer,
+      fields: {
+        add: mapInsertReducer
+      }
     }
   }
-})
+}, true)
 
 test('Initial state', (t) => {
   const stateAfter = {
@@ -55,7 +55,7 @@ test('Add model', (t) => {
 
 test('Update model', (t) => {
   const action = {
-    type: 'models[].update',
+    type: 'models.update',
     modelId: 'abcde',
     data: {
       name: 'updated model abcde'
@@ -100,7 +100,7 @@ test('Delete model', (t) => {
 
 test('Initial state of mapInsertReducer', (t) => {
   const action = {
-    type: 'models[].fields.add',
+    type: 'models.fields.add',
     modelId: 'abcde',
     insertKey: 'field 1',
     data: {

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -13,19 +13,18 @@ import { objectInsertReducer, objectDeleteReducer } from '../src/objectReducers'
 import { updateReducer } from '../src/updateReducers'
 
 const objectReducer = merge({
-  'models': {
-    '_': {},
-    'add': objectInsertReducer,
-    'delete': objectDeleteReducer
-  },
-  'models[modelId]': {
-    'update': updateReducer,
-    'fields': {
-      'add': objectInsertReducer
+  models: {
+    _: {},
+    add: objectInsertReducer,
+    delete: objectDeleteReducer,
+    $modelId: {
+      update: updateReducer,
+      fields: {
+        add: objectInsertReducer
+      }
     }
   }
-})
-
+}, true)
 
 test('Initial state', (t) => {
   const stateAfter = {
@@ -65,7 +64,7 @@ test('Insert model', (t) => {
 
 test('Update model', (t) => {
   const action = {
-    type: 'models[].update',
+    type: 'models.update',
     modelId: 'abcde',
     data: { name: 'updated model abcde' }
   }
@@ -119,7 +118,7 @@ test('Delete model', (t) => {
 
 test('Initial state of objectInsertReducer', (t) => {
   const action = {
-    type: 'models[].fields.add',
+    type: 'models.fields.add',
     modelId: 'abcde',
     insertKey: 'field 1',
     data: {


### PR DESCRIPTION
Refactor collection API and collection schema API to make the syntax more intuitive.

Collection nodes are now nested under its parent navigation node instead of existing alongside as a sibling. E.g.

``` js
const reducer = merge({
  user: {
    add: mapInsertReducer,
    update: updateReducer
  },
  'user[userId]': {
    items: {
      add: mapInsertReducer
    }
  }
})
```

becomes

``` js
const reducer = merge({
  user: {
    add: mapInsertReducer,
    update: updateReducer,
    $userId: {
      items: {
        add: mapInsertReducer
      }
    }
  }
})
```

The accessor key is now indicated by prepending a `$`, instead of inside square brackets. This schema becomes much more intuitive.

As for actions, we now intelligently search collection nodes for matching actions, meaning you can (or actually, must) omit the square brackets that used to be for indicating a collection node:

``` js
const action = {
  type: 'users[].fields.add',
  userId: 132,
  data: {
    fieldName: 'field1'
  }
}
```

simply becomes:

``` js
const action = {
  type: 'users.fields.add',
  userId: 132,
  data: {
    fieldName: 'field1'
  }
}
```

Also modified the test suites to reflect the above changes.
